### PR TITLE
Mapper work

### DIFF
--- a/pkg/fit/FitMapValue.go
+++ b/pkg/fit/FitMapValue.go
@@ -26,8 +26,8 @@ func FitMapValue(in reflect.Value) reflect.Value {
 	for it := in.MapRange(); it.Next(); {
 		k := reflect.ValueOf(it.Key().Interface())
 		v := FitValue(reflect.ValueOf(it.Value().Interface()))
-		keyTypes[k.Type().Name()] = k.Type()
-		valueTypes[v.Type().Name()] = v.Type()
+		keyTypes[k.Type().PkgPath()+"."+k.Type().String()] = k.Type()
+		valueTypes[v.Type().PkgPath()+"."+v.Type().String()] = v.Type()
 		m.SetMapIndex(k, v)
 	}
 
@@ -57,7 +57,6 @@ func FitMapValue(in reflect.Value) reflect.Value {
 			out.SetMapIndex(reflect.ValueOf(it.Key().Interface()), reflect.ValueOf(it.Value().Interface()))
 		}
 		return out
-
 	}
 
 	// If more than 1 key type, but only 1 value type.

--- a/pkg/fit/fit_test.go
+++ b/pkg/fit/fit_test.go
@@ -28,6 +28,11 @@ func TestFitMapStringString(t *testing.T) {
 	assert.Equal(t, map[string]string{"a": "x", "b": "y", "c": "z"}, out)
 }
 
+func TestFitMapStringInterfaceMapStringString(t *testing.T) {
+	out := Fit(map[string]interface{}{"@type": "null"})
+	assert.Equal(t, map[string]string{"@type": "null"}, out)
+}
+
 func TestFitMapStringInterface(t *testing.T) {
 	out := Fit(map[interface{}]interface{}{"a": true, "b": 1, "c": "z"})
 	assert.Equal(t, map[string]interface{}{"a": true, "b": 1, "c": "z"}, out)

--- a/pkg/mapper/IsEmpty.go
+++ b/pkg/mapper/IsEmpty.go
@@ -1,0 +1,32 @@
+// =================================================================
+//
+// Copyright (C) 2019 Spatial Current, Inc. - All Rights Reserved
+// Released as open source under the MIT License.  See LICENSE file.
+//
+// =================================================================
+
+package mapper
+
+import (
+	"reflect"
+)
+
+// IsEmpty returns true if the value is "empty".
+// If the type is nil, then returns true.
+// If the value is of kind array, map, slice, or string and if length is zero, then returns true.
+// If the value is of kind chan, func, interface, or pointer, and is not valid or nil, then returns true.
+// In all other cases, returns false.
+func IsEmpty(v interface{}) bool {
+	if t := reflect.TypeOf(v); t != nil {
+		switch t.Kind() {
+		case reflect.Chan, reflect.Func, reflect.Interface, reflect.Ptr:
+			return (!reflect.ValueOf(v).IsValid()) || reflect.ValueOf(v).IsNil()
+		case reflect.Array, reflect.String, reflect.Map, reflect.Slice:
+			return reflect.ValueOf(v).Len() == 0
+		default:
+			return false
+		}
+	}
+	// if the type of the value is nil
+	return true
+}

--- a/pkg/mapper/IsEmptyValue.go
+++ b/pkg/mapper/IsEmptyValue.go
@@ -11,7 +11,7 @@ import (
 	"reflect"
 )
 
-// IsEmpty returns true if the value is "empty".
+// IsEmptyValue returns true if the value is "empty".
 //  - If the type is nil, then returns true.
 //  - If the kind is bool, and the value is false, then returns true.
 //  - If the value is an integer, unsigned integer, or float, and the value if zero, then returns true.

--- a/pkg/mapper/IsEmptyValue.go
+++ b/pkg/mapper/IsEmptyValue.go
@@ -19,6 +19,20 @@ import (
 //  - If the value is of kind chan, func, interface, or pointer, and is not valid or nil, then returns true.
 //  - In all other cases, returns false.
 // IsEmptyValue is adapted from the isEmptyValue function in the `encoding/json` package, but adds support for additional types.
-func IsEmpty(v interface{}) bool {
-	return IsEmptyValue(reflect.ValueOf(v))
+func IsEmptyValue(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		return v.Len() == 0
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Ptr:
+		return (!v.IsValid()) || v.IsNil()
+	}
+	return false
 }

--- a/pkg/mapper/IsEmpty_test.go
+++ b/pkg/mapper/IsEmpty_test.go
@@ -15,4 +15,20 @@ import (
 
 func TestIsEmptyString(t *testing.T) {
 	assert.True(t, IsEmpty(""))
+	assert.False(t, IsEmpty("hello world"))
+}
+
+func TestIsEmptySlice(t *testing.T) {
+	assert.True(t, IsEmpty([]string{}))
+	assert.False(t, IsEmpty([]string{"hello world"}))
+}
+
+func TestIsEmptyMap(t *testing.T) {
+	assert.True(t, IsEmpty(map[string]string{}))
+	assert.False(t, IsEmpty(map[string]string{"hello": "world"}))
+}
+
+func TestIsEmptyInt(t *testing.T) {
+	assert.True(t, IsEmpty(0))
+	assert.False(t, IsEmpty(1))
 }

--- a/pkg/mapper/IsEmpty_test.go
+++ b/pkg/mapper/IsEmpty_test.go
@@ -1,0 +1,18 @@
+// =================================================================
+//
+// Copyright (C) 2019 Spatial Current, Inc. - All Rights Reserved
+// Released as open source under the MIT License.  See LICENSE file.
+//
+// =================================================================
+
+package mapper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsEmptyString(t *testing.T) {
+	assert.True(t, IsEmpty(""))
+}

--- a/pkg/mapper/Marshal.go
+++ b/pkg/mapper/Marshal.go
@@ -28,14 +28,14 @@ func Marshal(object interface{}) (interface{}, error) {
 		return nil, nil
 	}
 
-	// If value is a pointer and nil, then return nil
-	if k := v.Kind(); (k == reflect.Ptr || k == reflect.Map) && v.IsNil() {
-		return nil, nil
+	// Chase pointers
+	for v.IsValid() && reflect.ValueOf(v.Interface()).Kind() == reflect.Ptr {
+		v = v.Elem()
 	}
 
-	// Chase pointers
-	for reflect.TypeOf(v.Interface()).Kind() == reflect.Ptr {
-		v = v.Elem()
+	// If value is nil and a a pointer, slice or map, then return nil
+	if k := v.Kind(); (k == reflect.Ptr || k == reflect.Slice || k == reflect.Map) && v.IsNil() {
+		return nil, nil
 	}
 
 	c := v.Interface()
@@ -137,8 +137,9 @@ func Marshal(object interface{}) (interface{}, error) {
 				continue
 			}
 
-			// If value is a pointer and nil, then return nil
-			if k := fv.Kind(); (k == reflect.Ptr || k == reflect.Map) && fv.IsNil() {
+			// If value is nil
+			if k := fv.Kind(); (k == reflect.Ptr || k == reflect.Map || k == reflect.Slice) && fv.IsNil() {
+				// If omitempty struct tag attribute was present, then skip.
 				if omitEmpty {
 					continue
 				}

--- a/pkg/mapper/Marshal.go
+++ b/pkg/mapper/Marshal.go
@@ -73,6 +73,48 @@ func Marshal(object interface{}) (interface{}, error) {
 		return out, nil
 	}
 
+	// If input is a map of literals to literals.
+	switch m := object.(type) {
+	case map[int]float64:
+		return m, nil
+	case map[int]*float64:
+		return m, nil
+	case map[int]int:
+		return m, nil
+	case map[int]*int:
+		return m, nil
+	case map[int]string:
+		return m, nil
+	case map[int]*string:
+		return m, nil
+
+	case map[string]float64:
+		return m, nil
+	case map[string]*float64:
+		return m, nil
+	case map[string]int:
+		return m, nil
+	case map[string]*int:
+		return m, nil
+	case map[string]string:
+		return m, nil
+	case map[string]*string:
+		return m, nil
+
+	case map[interface{}]float64:
+		return m, nil
+	case map[interface{}]*float64:
+		return m, nil
+	case map[interface{}]int:
+		return m, nil
+	case map[interface{}]*int:
+		return m, nil
+	case map[interface{}]string:
+		return m, nil
+	case map[interface{}]*string:
+		return m, nil
+	}
+
 	in := reflect.ValueOf(c) // sets value to concerete type
 	t := v.Type()
 	k := t.Kind()

--- a/pkg/mapper/Marshal.go
+++ b/pkg/mapper/Marshal.go
@@ -92,7 +92,7 @@ func Marshal(object interface{}) (interface{}, error) {
 
 	// If input is of kind map.
 	if k == reflect.Map {
-		out := reflect.MakeMapWithSize(t, v.Len())
+		out := reflect.MakeMapWithSize(reflect.MapOf(t.Key(), interfaceType), v.Len())
 		for it := in.MapRange(); it.Next(); {
 			v, err := Marshal(it.Value().Interface())
 			if err != nil {

--- a/pkg/mapper/Marshal.go
+++ b/pkg/mapper/Marshal.go
@@ -44,7 +44,7 @@ func Marshal(object interface{}) (interface{}, error) {
 		return marshaler.MarshalMap()
 	}
 
-	// If input is a slice of pointers to literals.
+	// If input is a slice of literals or pointers to literals.
 	switch slc := object.(type) {
 	case []string:
 		return slc, nil
@@ -161,11 +161,6 @@ func Marshal(object interface{}) (interface{}, error) {
 		return out, nil
 	}
 
-	// If the concerete type of the input is a string, int, or float64.
-	switch k {
-	case reflect.String, reflect.Int, reflect.Float64:
-		return in.Interface(), nil
-	}
-
-	return object, nil
+	// return concerete value
+	return c, nil
 }

--- a/pkg/mapper/Marshal.go
+++ b/pkg/mapper/Marshal.go
@@ -18,6 +18,17 @@ func Marshal(object interface{}) (interface{}, error) {
 
 	v := reflect.ValueOf(object)
 
+	// If value is not valid or nil, return nil.
+	if !v.IsValid() {
+		return nil, nil
+	}
+
+	// If value is a pointer and nil, then return nil
+	if k := v.Kind(); (k == reflect.Ptr || k == reflect.Map) && v.IsNil() {
+		return nil, nil
+	}
+
+	// Chase pointers
 	for reflect.TypeOf(v.Interface()).Kind() == reflect.Ptr {
 		v = v.Elem()
 	}

--- a/pkg/mapper/Marshal.go
+++ b/pkg/mapper/Marshal.go
@@ -8,8 +8,9 @@
 package mapper
 
 import (
-	"github.com/pkg/errors"
 	"reflect"
+
+	"github.com/pkg/errors"
 
 	"github.com/spatialcurrent/go-simple-serializer/pkg/tagger"
 )

--- a/pkg/mapper/Marshal.go
+++ b/pkg/mapper/Marshal.go
@@ -1,0 +1,91 @@
+// =================================================================
+//
+// Copyright (C) 2019 Spatial Current, Inc. - All Rights Reserved
+// Released as open source under the MIT License.  See LICENSE file.
+//
+// =================================================================
+
+package mapper
+
+import (
+	"github.com/pkg/errors"
+	"reflect"
+
+	"github.com/spatialcurrent/go-simple-serializer/pkg/tagger"
+)
+
+func Marshal(object interface{}) (interface{}, error) {
+
+	v := reflect.ValueOf(object)
+
+	for reflect.TypeOf(v.Interface()).Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+
+	c := v.Interface()
+
+	// If inputs implements the Marshaler interface.
+	if marshaler, ok := c.(Marshaler); ok {
+		return marshaler.MarshalMap()
+	}
+
+	in := reflect.ValueOf(c) // sets value to concerete type
+	t := v.Type()
+	k := t.Kind()
+
+	// If input is of kind map
+	if k == reflect.Map {
+		out := reflect.MakeMapWithSize(t, v.Len())
+		for it := in.MapRange(); it.Next(); {
+			v, err := Marshal(it.Value().Interface())
+			if err != nil {
+				return nil, errors.Wrapf(err, "error marshaling %#v", it.Value().Interface())
+			}
+			out.SetMapIndex(it.Key(), reflect.ValueOf(v))
+		}
+		return out.Interface(), nil
+	}
+
+	// If input is of kind struct
+	if k == reflect.Struct {
+
+		out := make(map[string]interface{}, in.NumField())
+		for i := 0; i < in.NumField(); i++ {
+			f := t.Field(i)               // field
+			fv := in.Field(i).Interface() // field value
+
+			tagValue, err := tagger.Lookup(f.Tag, "map")
+			if err != nil {
+				return nil, errors.Wrapf(err, "error unmarshaling struct tag value %q", f.Tag)
+			}
+
+			key := f.Name
+			omitEmpty := false
+			if tagValue != nil {
+				if tagValue.Ignore {
+					continue
+				}
+				if len(tagValue.Name) > 0 {
+					key = tagValue.Name
+				}
+				omitEmpty = tagValue.OmitEmpty
+			}
+
+			// Marshal the underlying value
+			mfv, err := Marshal(fv)
+			if err != nil {
+				return nil, errors.Wrapf(err, "error marshaling value for field %v", f.Name)
+			}
+
+			// If marshaled field value is empty
+			if IsEmpty(mfv) && omitEmpty {
+				continue
+			}
+
+			out[key] = mfv
+		}
+		return out, nil
+	}
+
+	return object, nil
+}

--- a/pkg/mapper/Marshal_test.go
+++ b/pkg/mapper/Marshal_test.go
@@ -1,0 +1,72 @@
+// =================================================================
+//
+// Copyright (C) 2019 Spatial Current, Inc. - All Rights Reserved
+// Released as open source under the MIT License.  See LICENSE file.
+//
+// =================================================================
+
+package mapper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type testMarshaler string
+
+func (t testMarshaler) MarshalMap() (interface{}, error) {
+	return map[string]interface{}{"value": string(t)}, nil
+}
+
+func TestMarshalString(t *testing.T) {
+	out, err := Marshal("hello world")
+	assert.NoError(t, err)
+	assert.Equal(t, "hello world", out)
+}
+
+func TestMarshalMapStringInterace(t *testing.T) {
+	m, err := Marshal(map[string]interface{}{"foo": "bar"})
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]interface{}{"foo": "bar"}, m)
+}
+
+func TestMarshalMapInterfaceFloat(t *testing.T) {
+	m, err := Marshal(map[interface{}]float64{"yo": 1.2})
+	assert.NoError(t, err)
+	assert.Equal(t, map[interface{}]float64{"yo": 1.2}, m)
+}
+
+func TestMarshalMapStringString(t *testing.T) {
+	m, err := Marshal(map[string]string{"foo": "bar"})
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{"foo": "bar"}, m)
+}
+
+func TestMarshalMapStruct(t *testing.T) {
+	m, err := Marshal(struct{ Foo string }{Foo: "bar"})
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]interface{}{"Foo": "bar"}, m)
+}
+
+func TestMarshalMapStructTagged(t *testing.T) {
+	m, err := Marshal(struct {
+		Foo string `map:"foo"`
+	}{Foo: "bar"})
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]interface{}{"foo": "bar"}, m)
+}
+
+func TestMarshalMapStructMarshaler(t *testing.T) {
+	m, err := Marshal(testMarshaler("bar"))
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]interface{}{"value": "bar"}, m)
+}
+
+func TestMarshalMapStructMarshalerInside(t *testing.T) {
+	m, err := Marshal(map[string]interface{}{
+		"foo": testMarshaler("bar"),
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]interface{}{"foo": map[string]interface{}{"value": "bar"}}, m)
+}

--- a/pkg/mapper/Marshal_test.go
+++ b/pkg/mapper/Marshal_test.go
@@ -31,6 +31,26 @@ func TestMarshalString(t *testing.T) {
 	assert.Equal(t, "hello world", out)
 }
 
+func TestMarshalStringPointer(t *testing.T) {
+	foo := "foo"
+	out, err := Marshal(&foo)
+	assert.NoError(t, err)
+	assert.Equal(t, "foo", out)
+}
+
+func TestMarshalSliceString(t *testing.T) {
+	out, err := Marshal([]string{"foo", "bar"})
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"foo", "bar"}, out)
+}
+
+func TestMarshalSliceStringPointer(t *testing.T) {
+	foo := "foo"
+	out, err := Marshal([]*string{&foo})
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"foo"}, out)
+}
+
 func TestMarshalMapStringInterace(t *testing.T) {
 	m, err := Marshal(map[string]interface{}{"foo": "bar"})
 	assert.NoError(t, err)

--- a/pkg/mapper/Marshal_test.go
+++ b/pkg/mapper/Marshal_test.go
@@ -19,6 +19,12 @@ func (t testMarshaler) MarshalMap() (interface{}, error) {
 	return map[string]interface{}{"value": string(t)}, nil
 }
 
+func TestMarshalNil(t *testing.T) {
+	out, err := Marshal(nil)
+	assert.NoError(t, err)
+	assert.Nil(t, out)
+}
+
 func TestMarshalString(t *testing.T) {
 	out, err := Marshal("hello world")
 	assert.NoError(t, err)

--- a/pkg/mapper/Unmarshal.go
+++ b/pkg/mapper/Unmarshal.go
@@ -1,0 +1,106 @@
+// =================================================================
+//
+// Copyright (C) 2019 Spatial Current, Inc. - All Rights Reserved
+// Released as open source under the MIT License.  See LICENSE file.
+//
+// =================================================================
+
+package mapper
+
+import (
+	"github.com/pkg/errors"
+	"reflect"
+
+	"github.com/spatialcurrent/go-simple-serializer/pkg/fit"
+	"github.com/spatialcurrent/go-simple-serializer/pkg/tagger"
+)
+
+// Unmarshal unmarshaling the source data into the target converting maps to structs as indicated by struct tags.
+func Unmarshal(data interface{}, v interface{}) error {
+
+	// If inputs implements the Marshaler interface.
+	if unmarshaler, ok := v.(Unmarshaler); ok {
+		return unmarshaler.UnmarshalMap(data)
+	}
+
+	sourceValue := reflect.ValueOf(data)
+	sourceType := sourceValue.Type()
+	sourceKind := sourceType.Kind()
+
+	// Chase pointers to concerete value
+	targetValue := reflect.ValueOf(v)
+	for reflect.TypeOf(targetValue.Interface()).Kind() == reflect.Ptr {
+		targetValue = targetValue.Elem()
+	}
+	targetType := targetValue.Type()
+	targetKind := targetType.Kind()
+
+	if targetKind == reflect.Map {
+		if sourceKind == reflect.Map {
+			if !sourceType.Key().AssignableTo(targetType.Key()) {
+				return errors.Errorf("source map key %q is not assignable to target map key %q", sourceType.Key(), targetType.Key())
+			}
+			for it := sourceValue.MapRange(); it.Next(); {
+				v := reflect.New(targetType.Elem())
+				err := Unmarshal(it.Value().Interface(), v.Interface())
+				if err != nil {
+					return errors.Wrapf(err, "error unmarshaling %#v", it.Value().Interface())
+				}
+				if t := reflect.TypeOf(v); !t.AssignableTo(targetType.Elem()) {
+					return errors.Errorf("source map value %v is not assignable to target map value %v", t, targetType.Elem())
+				}
+				targetValue.SetMapIndex(it.Key(), v)
+			}
+		}
+		return nil
+	}
+
+	if targetKind == reflect.Struct {
+		if sourceKind == reflect.Map {
+			if !reflect.TypeOf("").AssignableTo(sourceType.Key()) {
+				return errors.Errorf("string is not assignable to source map key %q", sourceType.Key())
+			}
+			for i := 0; i < targetValue.NumField(); i++ {
+				f := targetType.Field(i)   // field
+				fv := targetValue.Field(i) // field value
+				if f.Anonymous {
+					continue
+				}
+				if !fv.CanSet() {
+					continue
+				}
+				tagValue, err := tagger.Lookup(f.Tag, "map")
+				if err != nil {
+					return errors.Wrapf(err, "error unmarshaling struct tag value %q", f.Tag)
+				}
+				key := f.Name
+				if tagValue != nil {
+					if tagValue.Ignore {
+						continue
+					}
+					if len(tagValue.Name) > 0 {
+						key = tagValue.Name
+					}
+				}
+				mv := sourceValue.MapIndex(reflect.ValueOf(key))
+				if !mv.IsValid() {
+					// if key was not found
+					continue
+				}
+				v := reflect.ValueOf(mv.Interface())
+				if !v.Type().AssignableTo(f.Type) {
+					// If the raw value is not assignable, then try with the fitted value.
+					if fitted := fit.FitValue(v); fitted.Type().AssignableTo(f.Type) {
+						fv.Set(fitted)
+						continue
+					}
+					return errors.Errorf("key %q found, but value %#v (%s) not assignable to field %q with type %q", key, v, v, f.Name, f.Type)
+				}
+				fv.Set(v)
+			}
+			return nil
+		}
+	}
+
+	return nil
+}

--- a/pkg/mapper/Unmarshal.go
+++ b/pkg/mapper/Unmarshal.go
@@ -11,67 +11,11 @@ import (
 	"github.com/pkg/errors"
 	"reflect"
 
-	"github.com/spatialcurrent/go-simple-serializer/pkg/fit"
 	"github.com/spatialcurrent/go-simple-serializer/pkg/tagger"
 )
 
-func unmarshalEmptySlice(source reflect.Value, target reflect.Value) bool {
-	sourceKind := source.Kind()
-	targetKind := target.Kind()
-	if (sourceKind == reflect.Array || sourceKind == reflect.Slice) && (targetKind == reflect.Slice) {
-		if source.Len() == 0 {
-			target.Set(reflect.MakeSlice(target.Type(), 0, 0))
-			return true
-		}
-	}
-	return false
-}
-
-func unmarshalFieldValue(mapValue reflect.Value, target reflect.Value) error {
-	// if field implements Unmarshaler interface.
-	if target.Type().Implements(reflect.TypeOf((*Unmarshaler)(nil)).Elem()) {
-		value := reflect.New(target.Type().Elem())
-		result := value.MethodByName("UnmarshalMap").Call([]reflect.Value{mapValue})
-		err := result[0].Interface()
-		if err != nil {
-			return err.(error)
-		}
-		target.Set(value)
-		return nil
-	}
-
-	// If target is a pointer to a struct, then recurse.
-	if target.Type().Kind() == reflect.Ptr {
-		if target.Type().Elem().Kind() == reflect.Struct {
-			if !target.Elem().IsValid() {
-				target.Set(reflect.New(target.Type().Elem()))
-			}
-			return UnmarshalValue(mapValue, target)
-		}
-	}
-
-	// Attempt to unmarshal as an empty slice
-	if unmarshalEmptySlice(mapValue, target) {
-		return nil
-	}
-
-	if !mapValue.Type().AssignableTo(target.Type()) {
-		// If the raw value is not assignable, then try with the fitted value.
-		if fitted := fit.FitValue(mapValue); fitted.Type().AssignableTo(target.Type()) {
-			target.Set(fitted)
-			return nil
-		}
-		return errors.Errorf("value %#v (%q) not assignable to field type %q", mapValue.Interface(), mapValue.Type(), target.Type())
-	}
-	target.Set(mapValue)
-	return nil
-}
-
 // Unmarshal unmarshaling the source data into the target converting maps to structs as indicated by struct tags.
 func Unmarshal(data interface{}, v interface{}) error {
-	if unmarshaler, ok := v.(Unmarshaler); ok {
-		return unmarshaler.UnmarshalMap(data)
-	}
 	return UnmarshalValue(reflect.ValueOf(data), reflect.ValueOf(v))
 }
 
@@ -80,12 +24,46 @@ func UnmarshalValue(sourceValue reflect.Value, targetValue reflect.Value) error 
 	sourceType := sourceValue.Type()
 	sourceKind := sourceType.Kind()
 
+	if sourceKind == reflect.Interface {
+		return errors.Errorf("source %v (%T) is of kind interface", sourceValue, sourceValue)
+	}
+
 	//for reflect.TypeOf(targetValue.Interface()).Kind() == reflect.Ptr {
 	//	targetValue = targetValue.Elem()
 	//}
 	targetType := targetValue.Type()
 	targetKind := targetType.Kind()
 
+	// If target is of kind pointer, then dereference the target value.
+	if targetKind == reflect.Ptr {
+		return UnmarshalValue(sourceValue, targetValue.Elem())
+	}
+
+	if !targetValue.CanAddr() {
+		return errors.Errorf("target %#v (%v) is not addressable", targetValue.Interface(), targetValue.Type())
+	}
+
+	if !targetValue.CanSet() {
+		return errors.Errorf("target %#v (%v) cannot be set", targetValue.Interface(), targetValue.Type())
+	}
+
+	// If target implements the unmarshaler interface
+	if reflect.PtrTo(targetType).Implements(reflect.TypeOf((*Unmarshaler)(nil)).Elem()) {
+		outValue := reflect.New(targetType)
+		result := outValue.MethodByName("UnmarshalMap").Call([]reflect.Value{sourceValue})
+		err := result[0].Interface()
+		if err != nil {
+			return err.(error)
+		}
+		targetValue.Set(outValue.Elem())
+		return nil
+	}
+
+	if targetKind == reflect.Slice {
+		return UnmarshalSliceValue(sourceValue, targetValue)
+	}
+
+	// If target is a map
 	if targetKind == reflect.Map {
 		if sourceKind == reflect.Map {
 			if !sourceType.Key().AssignableTo(targetType.Key()) {
@@ -106,68 +84,70 @@ func UnmarshalValue(sourceValue reflect.Value, targetValue reflect.Value) error 
 		return nil
 	}
 
-	// If target is a pointer
-	if targetKind == reflect.Ptr {
+	// If target is a struct
+	if targetKind == reflect.Struct {
 
-		targetElemValue := targetValue.Elem()
-		targetElemType := targetValue.Type().Elem()
-		targetElemKind := targetElemType.Kind()
+		if sourceKind == reflect.Map {
 
-		// If target element is a struct
-		if targetElemKind == reflect.Struct {
-			if sourceKind == reflect.Map {
-				if !reflect.TypeOf("").AssignableTo(sourceType.Key()) {
-					return errors.Errorf("string is not assignable to source map key %q", sourceType.Key())
-				}
-
-				// Iterate throught the struct fields
-				for i := 0; i < targetElemValue.NumField(); i++ {
-					f := targetElemType.Field(i)   // field
-					fv := targetElemValue.Field(i) // field value
-					if f.Anonymous {
-						continue
-					}
-					if !fv.CanSet() {
-						continue
-					}
-					tagValue, err := tagger.Lookup(f.Tag, "map")
-					if err != nil {
-						return errors.Wrapf(err, "error unmarshaling struct tag value %q", f.Tag)
-					}
-					key := f.Name
-					if tagValue != nil {
-						if tagValue.Ignore {
-							continue
-						}
-						if len(tagValue.Name) > 0 {
-							key = tagValue.Name
-						}
-					}
-
-					mv := sourceValue.MapIndex(reflect.ValueOf(key))
-					if !mv.IsValid() {
-						// if key was not found
-						continue
-					}
-
-					// If source value is nil, then set target to its zero value.
-					if k := mv.Kind(); k == reflect.Map || k == reflect.Interface {
-						if mv.IsNil() {
-							fv.Set(reflect.Zero(fv.Type()))
-							continue
-						}
-					}
-
-					// unmarshal the concrete map value into the field
-					err = unmarshalFieldValue(reflect.ValueOf(mv.Interface()), fv)
-					if err != nil {
-						return errors.Wrapf(err, "key %q found, but could not assign to field %q", key, f.Name)
-					}
-				}
-				return nil
+			if !reflect.TypeOf("").AssignableTo(sourceType.Key()) {
+				return errors.Errorf("string is not assignable to source map key %q", sourceType.Key())
 			}
-		}
 
+			// Iterate throught the struct fields
+			for i := 0; i < targetValue.NumField(); i++ {
+				f := targetType.Field(i)   // field
+				fv := targetValue.Field(i) // field value
+
+				if f.Anonymous {
+					continue
+				}
+
+				if !fv.CanSet() {
+					continue
+				}
+
+				tagValue, err := tagger.Lookup(f.Tag, "map")
+				if err != nil {
+					return errors.Wrapf(err, "error unmarshaling struct tag value %q", f.Tag)
+				}
+
+				key := f.Name
+				if tagValue != nil {
+					if tagValue.Ignore {
+						continue
+					}
+					if len(tagValue.Name) > 0 {
+						key = tagValue.Name
+					}
+				}
+
+				mv := sourceValue.MapIndex(reflect.ValueOf(key))
+				if !mv.IsValid() {
+					// if key was not found
+					continue
+				}
+
+				// If source value is nil, then set target to its zero value.
+				if k := mv.Kind(); k == reflect.Map || k == reflect.Interface {
+					if mv.IsNil() {
+						fv.Set(reflect.Zero(fv.Type()))
+						continue
+					}
+				}
+
+				// unmarshal the concrete map value into the field
+				err = UnmarshalFieldValue(reflect.ValueOf(mv.Interface()), fv)
+				if err != nil {
+					return errors.Wrapf(err, "key %q found, but could not assign to field %q", key, f.Name)
+				}
+			}
+			return nil
+		}
+	}
+
+	// If source is assignale to target, then simply set it.
+	if sourceType.AssignableTo(targetType) {
+		targetValue.Set(sourceValue)
 	}
 
 	return nil

--- a/pkg/mapper/Unmarshal.go
+++ b/pkg/mapper/Unmarshal.go
@@ -8,7 +8,6 @@
 package mapper
 
 import (
-	//"fmt"
 	"github.com/pkg/errors"
 	"reflect"
 
@@ -17,8 +16,8 @@ import (
 )
 
 func unmarshalEmptySlice(source reflect.Value, target reflect.Value) bool {
-	sourceKind := source.Type().Kind()
-	targetKind := target.Type().Kind()
+	sourceKind := source.Kind()
+	targetKind := target.Kind()
 	if (sourceKind == reflect.Array || sourceKind == reflect.Slice) && (targetKind == reflect.Slice) {
 		if source.Len() == 0 {
 			target.Set(reflect.MakeSlice(target.Type(), 0, 0))
@@ -77,7 +76,6 @@ func Unmarshal(data interface{}, v interface{}) error {
 }
 
 func UnmarshalValue(sourceValue reflect.Value, targetValue reflect.Value) error {
-	//fmt.Println(fmt.Sprintf("UnmarshalValue(%#v, %#v)", sourceValue, targetValue))
 
 	sourceType := sourceValue.Type()
 	sourceKind := sourceType.Kind()
@@ -151,6 +149,15 @@ func UnmarshalValue(sourceValue reflect.Value, targetValue reflect.Value) error 
 						// if key was not found
 						continue
 					}
+
+					// If source value is nil, then set target to its zero value.
+					if k := mv.Kind(); k == reflect.Map || k == reflect.Interface {
+						if mv.IsNil() {
+							fv.Set(reflect.Zero(fv.Type()))
+							continue
+						}
+					}
+
 					// unmarshal the concrete map value into the field
 					err = unmarshalFieldValue(reflect.ValueOf(mv.Interface()), fv)
 					if err != nil {

--- a/pkg/mapper/Unmarshal.go
+++ b/pkg/mapper/Unmarshal.go
@@ -8,8 +8,9 @@
 package mapper
 
 import (
-	"github.com/pkg/errors"
 	"reflect"
+
+	"github.com/pkg/errors"
 
 	"github.com/spatialcurrent/go-simple-serializer/pkg/tagger"
 )

--- a/pkg/mapper/UnmarshalFieldValue.go
+++ b/pkg/mapper/UnmarshalFieldValue.go
@@ -1,0 +1,68 @@
+// =================================================================
+//
+// Copyright (C) 2019 Spatial Current, Inc. - All Rights Reserved
+// Released as open source under the MIT License.  See LICENSE file.
+//
+// =================================================================
+
+package mapper
+
+import (
+	//"fmt"
+	"github.com/pkg/errors"
+	"github.com/spatialcurrent/go-simple-serializer/pkg/fit"
+	"reflect"
+)
+
+func UnmarshalFieldValue(source reflect.Value, target reflect.Value) error {
+	//fmt.Println(fmt.Sprintf("UnmarshalFieldValue(%#v, %#v)\n", source, target))
+
+	targetType := target.Type()
+	targetKind := target.Kind()
+
+	// if field implements Unmarshaler interface.
+	if targetType.Implements(reflect.TypeOf((*Unmarshaler)(nil)).Elem()) {
+		value := reflect.New(target.Type().Elem())
+		result := value.MethodByName("UnmarshalMap").Call([]reflect.Value{source})
+		err := result[0].Interface()
+		if err != nil {
+			return err.(error)
+		}
+		target.Set(value)
+		return nil
+	}
+
+	// If target is a pointer
+	if targetKind == reflect.Ptr {
+
+		targetElemType := targetType.Elem()
+		targetElemKind := targetElemType.Kind()
+
+		// If target is a pointer to a struct
+		if targetElemKind == reflect.Struct {
+			if !target.Elem().IsValid() {
+				target.Set(reflect.New(target.Type().Elem()))
+			}
+			return UnmarshalValue(source, target)
+		}
+
+	}
+
+	// if target is a pointer to a slice
+	if targetKind == reflect.Slice {
+		return UnmarshalSliceValue(source, target)
+	}
+
+	if source.Type().AssignableTo(target.Type()) {
+		target.Set(source)
+		return nil
+	}
+
+	// If the raw value is not assignable, then try with the fitted value.
+	if fitted := fit.FitValue(source); fitted.Type().AssignableTo(target.Type()) {
+		target.Set(fitted)
+		return nil
+	}
+
+	return errors.Errorf("value %#v (%q) not assignable to field type %q", source.Interface(), source.Type(), target.Type())
+}

--- a/pkg/mapper/UnmarshalFieldValue.go
+++ b/pkg/mapper/UnmarshalFieldValue.go
@@ -8,14 +8,14 @@
 package mapper
 
 import (
-	//"fmt"
-	"github.com/pkg/errors"
-	"github.com/spatialcurrent/go-simple-serializer/pkg/fit"
 	"reflect"
+
+	"github.com/pkg/errors"
+
+	"github.com/spatialcurrent/go-simple-serializer/pkg/fit"
 )
 
 func UnmarshalFieldValue(source reflect.Value, target reflect.Value) error {
-	//fmt.Println(fmt.Sprintf("UnmarshalFieldValue(%#v, %#v)\n", source, target))
 
 	targetType := target.Type()
 	targetKind := target.Kind()

--- a/pkg/mapper/UnmarshalMap.go
+++ b/pkg/mapper/UnmarshalMap.go
@@ -1,0 +1,90 @@
+// =================================================================
+//
+// Copyright (C) 2019 Spatial Current, Inc. - All Rights Reserved
+// Released as open source under the MIT License.  See LICENSE file.
+//
+// =================================================================
+
+package mapper
+
+import (
+	"reflect"
+
+	"github.com/pkg/errors"
+)
+
+// UnmarshalMap unmarshals the given map into the value, and returns an error, if any.
+func UnmarshalMap(data interface{}, v interface{}) error {
+	if unmarshaler, ok := v.(Unmarshaler); ok {
+		return unmarshaler.UnmarshalMap(data)
+	}
+	return UnmarshalMapValue(reflect.ValueOf(data), reflect.ValueOf(v))
+}
+
+// UnmarshalMapValue unmarshals the given map value into the target map, and returns an error, if any.
+func UnmarshalMapValue(sourceValue reflect.Value, targetValue reflect.Value) error {
+
+	targetType := targetValue.Type()
+	targetKind := targetValue.Kind()
+
+	// If target is of kind pointer, then dereference the target value.
+	if targetKind == reflect.Ptr {
+		return UnmarshalMapValue(sourceValue, targetValue.Elem())
+	}
+
+	if !targetValue.CanAddr() {
+		return errors.Errorf("target %#v (%T) is not addressable", targetValue, targetValue)
+	}
+
+	if !targetValue.CanSet() {
+		return errors.Errorf("target %#v (%T) cannot be set", targetValue, targetValue)
+	}
+
+	if targetKind != reflect.Map {
+		return errors.Errorf("target element is of type %v, expecting kind of map", targetType)
+	}
+
+	if !sourceValue.IsValid() {
+		targetValue.Set(reflect.MakeMap(targetType))
+		return nil
+	}
+
+	sourceType := sourceValue.Type()
+	sourceKind := sourceValue.Kind()
+
+	// If source is of kind pointer, then dereference the source value.
+	if sourceKind == reflect.Ptr {
+		return UnmarshalMapValue(sourceValue.Elem(), targetValue)
+	}
+
+	// Only accept map input
+	if sourceKind != reflect.Map {
+		return errors.Errorf("source is of type %v, expecting kind of map", sourceValue.Type())
+	}
+
+	if sourceValue.Len() == 0 {
+		targetValue.Set(reflect.MakeMap(targetType))
+		return nil
+	}
+
+	if !sourceType.Key().AssignableTo(targetType.Key()) {
+		return errors.Errorf("source map key %q is not assignable to target map key %q", sourceType.Key(), targetType.Key())
+	}
+
+	// create the output slice
+	out := reflect.MakeMap(targetType)
+
+	for it := sourceValue.MapRange(); it.Next(); {
+		v := reflect.New(targetType.Elem())
+		err := UnmarshalValue(it.Value(), v.Elem())
+		if err != nil {
+			return errors.Wrapf(err, "error unmarshaling %#v", it.Value().Interface())
+		}
+		out.SetMapIndex(it.Key(), v.Elem())
+	}
+
+	// Set target to the new slice
+	targetValue.Set(out)
+
+	return nil
+}

--- a/pkg/mapper/UnmarshalMap_test.go
+++ b/pkg/mapper/UnmarshalMap_test.go
@@ -1,0 +1,48 @@
+// =================================================================
+//
+// Copyright (C) 2019 Spatial Current, Inc. - All Rights Reserved
+// Released as open source under the MIT License.  See LICENSE file.
+//
+// =================================================================
+
+package mapper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUmarshalMap(t *testing.T) {
+	in := map[string]interface{}{
+		"a": "x",
+		"b": "y",
+		"c": "z",
+	}
+	expected := map[string]string{
+		"a": "x",
+		"b": "y",
+		"c": "z",
+	}
+	out := map[string]string{}
+	err := UnmarshalMap(in, &out)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, out)
+}
+
+func TestUmarshalMapPointers(t *testing.T) {
+	in := map[string]interface{}{
+		"a": "x",
+		"b": "y",
+		"c": "z",
+	}
+	expected := map[string]string{
+		"a": "x",
+		"b": "y",
+		"c": "z",
+	}
+	out := map[string]string{}
+	err := UnmarshalMap(&in, &out)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, out)
+}

--- a/pkg/mapper/UnmarshalSlice.go
+++ b/pkg/mapper/UnmarshalSlice.go
@@ -72,7 +72,11 @@ func UnmarshalSliceValue(source reflect.Value, target reflect.Value) error {
 	} else {
 		for i := 0; i < source.Len(); i++ {
 			v := reflect.New(targetType.Elem())
-			v.Elem().Set(reflect.Zero(targetType.Elem()))
+			if targetType.Elem().Kind() == reflect.Map {
+				v.Elem().Set(reflect.MakeMap(targetType.Elem()))
+			} else {
+				v.Elem().Set(reflect.Zero(targetType.Elem()))
+			}
 			err := UnmarshalValue(reflect.ValueOf(source.Index(i).Interface()), v.Elem())
 			if err != nil {
 				return errors.Wrapf(err, "error unmarshaling slice value %d", i)

--- a/pkg/mapper/UnmarshalSlice.go
+++ b/pkg/mapper/UnmarshalSlice.go
@@ -8,8 +8,9 @@
 package mapper
 
 import (
-	"github.com/pkg/errors"
 	"reflect"
+
+	"github.com/pkg/errors"
 )
 
 // UnmarshalSlice unmarshals the given array or slice into the value, and returns an error, if any.

--- a/pkg/mapper/UnmarshalSlice.go
+++ b/pkg/mapper/UnmarshalSlice.go
@@ -1,0 +1,87 @@
+// =================================================================
+//
+// Copyright (C) 2019 Spatial Current, Inc. - All Rights Reserved
+// Released as open source under the MIT License.  See LICENSE file.
+//
+// =================================================================
+
+package mapper
+
+import (
+	"github.com/pkg/errors"
+	"reflect"
+)
+
+// UnmarshalSlice unmarshals the given array or slice into the value, and returns an error, if any.
+func UnmarshalSlice(data interface{}, v interface{}) error {
+	if unmarshaler, ok := v.(Unmarshaler); ok {
+		return unmarshaler.UnmarshalMap(data)
+	}
+	return UnmarshalSliceValue(reflect.ValueOf(data), reflect.ValueOf(v))
+}
+
+// UnmarshalSlice unmarshals the given array or slice value into the pointer to slice value, and returns an error, if any.
+func UnmarshalSliceValue(source reflect.Value, target reflect.Value) error {
+
+	sourceKind := source.Kind()
+
+	// Only accept array or slice input
+	if sourceKind != reflect.Array && sourceKind != reflect.Slice {
+		return errors.Errorf("source is of type %v, expecting kind of array or slice", source.Type())
+	}
+
+	targetType := target.Type()
+	targetKind := target.Kind()
+
+	// If target is of kind pointer, then dereference the target value.
+	if targetKind == reflect.Ptr {
+		return UnmarshalSliceValue(source, target.Elem())
+	}
+
+	if !target.CanAddr() {
+		return errors.Errorf("target %#v (%T) is not addressable", target, target)
+	}
+
+	if !target.CanSet() {
+		return errors.Errorf("target %#v (%T) cannot be set", target, target)
+	}
+
+	if targetKind != reflect.Slice {
+		return errors.Errorf("target element is of type %v, expecting kind of slice", targetType)
+	}
+
+	if source.Len() == 0 {
+		target.Set(reflect.MakeSlice(targetType, 0, 0))
+		return nil
+	}
+
+	// create the output slice
+	out := reflect.MakeSlice(targetType, 0, source.Len())
+
+	if targetType.Elem().Kind() == reflect.Ptr {
+		for i := 0; i < source.Len(); i++ {
+			v := reflect.New(targetType.Elem().Elem())
+			v.Elem().Set(reflect.Zero(targetType.Elem().Elem()))
+			err := UnmarshalValue(reflect.ValueOf(source.Index(i).Interface()), v.Elem())
+			if err != nil {
+				return errors.Wrapf(err, "error unmarshaling slice value %d", i)
+			}
+			out = reflect.Append(out, v)
+		}
+	} else {
+		for i := 0; i < source.Len(); i++ {
+			v := reflect.New(targetType.Elem())
+			v.Elem().Set(reflect.Zero(targetType.Elem()))
+			err := UnmarshalValue(reflect.ValueOf(source.Index(i).Interface()), v.Elem())
+			if err != nil {
+				return errors.Wrapf(err, "error unmarshaling slice value %d", i)
+			}
+			out = reflect.Append(out, v.Elem())
+		}
+	}
+
+	// Set target to the new slice
+	target.Set(out)
+
+	return nil
+}

--- a/pkg/mapper/UnmarshalSlice.go
+++ b/pkg/mapper/UnmarshalSlice.go
@@ -21,7 +21,7 @@ func UnmarshalSlice(data interface{}, v interface{}) error {
 	return UnmarshalSliceValue(reflect.ValueOf(data), reflect.ValueOf(v))
 }
 
-// UnmarshalSlice unmarshals the given array or slice value into the pointer to slice value, and returns an error, if any.
+// UnmarshalSliceValue unmarshals the given array or slice value into the pointer to slice value, and returns an error, if any.
 func UnmarshalSliceValue(source reflect.Value, target reflect.Value) error {
 
 	sourceKind := source.Kind()

--- a/pkg/mapper/UnmarshalSlice_test.go
+++ b/pkg/mapper/UnmarshalSlice_test.go
@@ -1,0 +1,60 @@
+// =================================================================
+//
+// Copyright (C) 2019 Spatial Current, Inc. - All Rights Reserved
+// Released as open source under the MIT License.  See LICENSE file.
+//
+// =================================================================
+
+package mapper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnmarshalSlice(t *testing.T) {
+	in := []interface{}{
+		map[string]interface{}{
+			"a": "x",
+			"b": "y",
+			"c": "z",
+			"d": []interface{}{"x", "y", "z"},
+		},
+	}
+	expected := []testStruct{
+		testStruct{
+			A: "x",
+			B: "y",
+			C: "",
+			D: []string{"x", "y", "z"},
+		},
+	}
+	out := []testStruct{}
+	err := UnmarshalSlice(in, &out)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, out)
+}
+
+func TestUnmarshalSlicePointers(t *testing.T) {
+	in := []interface{}{
+		map[string]interface{}{
+			"a": "x",
+			"b": "y",
+			"c": "z",
+			"d": []interface{}{"x", "y", "z"},
+		},
+	}
+	expected := []*testStruct{
+		&testStruct{
+			A: "x",
+			B: "y",
+			C: "",
+			D: []string{"x", "y", "z"},
+		},
+	}
+	out := []*testStruct{}
+	err := UnmarshalSlice(in, &out)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, out)
+}

--- a/pkg/mapper/Unmarshal_test.go
+++ b/pkg/mapper/Unmarshal_test.go
@@ -1,0 +1,77 @@
+// =================================================================
+//
+// Copyright (C) 2019 Spatial Current, Inc. - All Rights Reserved
+// Released as open source under the MIT License.  See LICENSE file.
+//
+// =================================================================
+
+package mapper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type testStruct struct {
+	A string   `map:"a"`
+	B string   `map:"b,omitempty"`
+	C string   `map:"-"`
+	D []string `map:"d,omitempty"`
+}
+
+func TestUnmarshalMap(t *testing.T) {
+	in := map[string]interface{}{
+		"a": "x",
+		"b": "y",
+		"c": "z",
+	}
+	expected := &testStruct{
+		A: "x",
+		B: "y",
+		C: "",
+		D: nil,
+	}
+	out := &testStruct{}
+	err := Unmarshal(in, out)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, out)
+}
+
+func TestUnmarshalMapSlice(t *testing.T) {
+	in := map[string]interface{}{
+		"a": "x",
+		"b": "y",
+		"c": "z",
+		"d": []string{"x", "y", "z"},
+	}
+	expected := &testStruct{
+		A: "x",
+		B: "y",
+		C: "",
+		D: []string{"x", "y", "z"},
+	}
+	out := &testStruct{}
+	err := Unmarshal(in, out)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, out)
+}
+
+func TestUnmarshalMapInterfaceSlice(t *testing.T) {
+	in := map[string]interface{}{
+		"a": "x",
+		"b": "y",
+		"c": "z",
+		"d": []interface{}{"x", "y", "z"},
+	}
+	expected := &testStruct{
+		A: "x",
+		B: "y",
+		C: "",
+		D: []string{"x", "y", "z"},
+	}
+	out := &testStruct{}
+	err := Unmarshal(in, out)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, out)
+}

--- a/pkg/mapper/Unmarshal_test.go
+++ b/pkg/mapper/Unmarshal_test.go
@@ -13,13 +13,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type testStruct struct {
-	A string   `map:"a"`
-	B string   `map:"b,omitempty"`
-	C string   `map:"-"`
-	D []string `map:"d,omitempty"`
-}
-
 func TestUnmarshalMap(t *testing.T) {
 	in := map[string]interface{}{
 		"a": "x",
@@ -71,6 +64,33 @@ func TestUnmarshalMapInterfaceSlice(t *testing.T) {
 		D: []string{"x", "y", "z"},
 	}
 	out := &testStruct{}
+	err := Unmarshal(in, out)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, out)
+}
+
+func TestUnmarshalStructSliceStructs(t *testing.T) {
+	in := map[string]interface{}{
+		"objects": []interface{}{
+			map[string]interface{}{
+				"a": "x",
+				"b": "y",
+				"c": "z",
+				"d": []interface{}{"x", "y", "z"},
+			},
+		},
+	}
+	expected := &testObjects{
+		Objects: []*testStruct{
+			&testStruct{
+				A: "x",
+				B: "y",
+				C: "",
+				D: []string{"x", "y", "z"},
+			},
+		},
+	}
+	out := &testObjects{}
 	err := Unmarshal(in, out)
 	assert.NoError(t, err)
 	assert.Equal(t, expected, out)

--- a/pkg/mapper/mapper.go
+++ b/pkg/mapper/mapper.go
@@ -1,0 +1,17 @@
+// =================================================================
+//
+// Copyright (C) 2019 Spatial Current, Inc. - All Rights Reserved
+// Released as open source under the MIT License.  See LICENSE file.
+//
+// =================================================================
+
+// Package mapper provides a simple api for serializing objects to maps.
+package mapper
+
+type Marshaler interface {
+	MarshalMap() (interface{}, error)
+}
+
+type Unmarshaler interface {
+	UnmarshalMap(data interface{}) error
+}

--- a/pkg/mapper/mapper.go
+++ b/pkg/mapper/mapper.go
@@ -10,6 +10,10 @@
 // For example, using map struct tags, you can provide a single representation to JSON, YAML, and TOML serializers.
 package mapper
 
+import (
+	"reflect"
+)
+
 type Marshaler interface {
 	MarshalMap() (interface{}, error)
 }
@@ -17,3 +21,5 @@ type Marshaler interface {
 type Unmarshaler interface {
 	UnmarshalMap(data interface{}) error
 }
+
+var interfaceType = reflect.TypeOf([]interface{}{}).Elem()

--- a/pkg/mapper/mapper.go
+++ b/pkg/mapper/mapper.go
@@ -5,7 +5,9 @@
 //
 // =================================================================
 
-// Package mapper provides a simple api for serializing objects to maps.
+// Package mapper provides a simple api for serializing structs to maps and pointers to their concerete types.
+// This package is useful for providing a single execution path for serializing to file formats.
+// For example, using map struct tags, you can provide a single representation to JSON, YAML, and TOML serializers.
 package mapper
 
 type Marshaler interface {

--- a/pkg/mapper/mapper_test.go
+++ b/pkg/mapper/mapper_test.go
@@ -6,3 +6,14 @@
 // =================================================================
 
 package mapper
+
+type testStruct struct {
+	A string   `map:"a"`
+	B string   `map:"b,omitempty"`
+	C string   `map:"-"`
+	D []string `map:"d,omitempty"`
+}
+
+type testObjects struct {
+	Objects []*testStruct `map:"objects"`
+}

--- a/pkg/mapper/mapper_test.go
+++ b/pkg/mapper/mapper_test.go
@@ -1,0 +1,8 @@
+// =================================================================
+//
+// Copyright (C) 2019 Spatial Current, Inc. - All Rights Reserved
+// Released as open source under the MIT License.  See LICENSE file.
+//
+// =================================================================
+
+package mapper

--- a/pkg/serializer/Serializer.go
+++ b/pkg/serializer/Serializer.go
@@ -141,9 +141,10 @@ type Serializer struct {
 // New returns a new serializer with the given format.
 func New(format string) *Serializer {
 	return &Serializer{
-		format:    format,
-		skipLines: NoSkip,
-		limit:     NoLimit,
+		format:        format,
+		skipLines:     NoSkip,
+		limit:         NoLimit,
+		lineSeparator: "\n",
 	}
 }
 

--- a/pkg/tagger/KeyValue.go
+++ b/pkg/tagger/KeyValue.go
@@ -1,0 +1,30 @@
+// =================================================================
+//
+// Copyright (C) 2019 Spatial Current, Inc. - All Rights Reserved
+// Released as open source under the MIT License.  See LICENSE file.
+//
+// =================================================================
+
+// Package tagger includes a struct for marshaling and unmarshaling struct tags.
+package tagger
+
+import (
+	"fmt"
+	"github.com/pkg/errors"
+)
+
+// KeyValue represents a struct tag key:"value" pair.
+type KeyValue struct {
+	Key   string
+	Value Value
+}
+
+// MarshalText returns the KeyValue formatted as a struct tag key:"value" pairs.
+// Always returns a nil error.
+func (t KeyValue) MarshalText() ([]byte, error) {
+	v, err := t.Value.MarshalText()
+	if err != nil {
+		return make([]byte, 0), errors.Wrapf(err, "error marshaling %#v", t)
+	}
+	return []byte(fmt.Sprintf("%s:%q", t.Key, string(v))), nil
+}

--- a/pkg/tagger/KeyValue.go
+++ b/pkg/tagger/KeyValue.go
@@ -10,6 +10,7 @@ package tagger
 
 import (
 	"fmt"
+
 	"github.com/pkg/errors"
 )
 

--- a/pkg/tagger/Lookup.go
+++ b/pkg/tagger/Lookup.go
@@ -1,0 +1,28 @@
+// =================================================================
+//
+// Copyright (C) 2019 Spatial Current, Inc. - All Rights Reserved
+// Released as open source under the MIT License.  See LICENSE file.
+//
+// =================================================================
+
+package tagger
+
+import (
+	"github.com/pkg/errors"
+	"reflect"
+)
+
+// Lookup lookups and parses a struct tag key-value pair if found.
+// If the lookup key is not found, then returns (nil, nil).
+// Returns an error if there was an error unmarshaling the value of the struct tag key-value pair.
+func Lookup(structTag reflect.StructTag, key string) (*Value, error) {
+	if str, ok := structTag.Lookup(key); ok {
+		v := &Value{}
+		err := Unmarshal([]byte(str), v)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error unmarshaling struct tag value %q", str)
+		}
+		return v, nil
+	}
+	return nil, nil
+}

--- a/pkg/tagger/Lookup.go
+++ b/pkg/tagger/Lookup.go
@@ -8,8 +8,9 @@
 package tagger
 
 import (
-	"github.com/pkg/errors"
 	"reflect"
+
+	"github.com/pkg/errors"
 )
 
 // Lookup lookups and parses a struct tag key-value pair if found.

--- a/pkg/tagger/Lookup_test.go
+++ b/pkg/tagger/Lookup_test.go
@@ -21,7 +21,7 @@ type testStruct struct {
 }
 
 func testLookup(t *testing.T, in string, key string, expected *Value) {
-	v, err := Lookup(in, key)
+	v, err := Lookup(reflect.StructTag(in), key)
 	assert.NoError(t, err)
 	assert.Equal(t, expected, v)
 	out, err := v.MarshalText()

--- a/pkg/tagger/Lookup_test.go
+++ b/pkg/tagger/Lookup_test.go
@@ -1,0 +1,60 @@
+// =================================================================
+//
+// Copyright (C) 2019 Spatial Current, Inc. - All Rights Reserved
+// Released as open source under the MIT License.  See LICENSE file.
+//
+// =================================================================
+
+package tagger
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type testStruct struct {
+	A string `name:"a"`
+	B string `name:"b,omitempty"`
+	C string `name:"-"`
+}
+
+func testLookup(t *testing.T, in string, key string, expected *Value) {
+	v, err := Lookup(in, key)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, v)
+	out, err := v.MarshalText()
+	assert.NoError(t, err)
+	assert.Equal(t, reflect.StructTag(in).Get(key), string(out))
+}
+
+func TestLookup(t *testing.T) {
+	in := `name:"a" json:"b"`
+	expected := &Value{
+		Ignore:    false,
+		Name:      "a",
+		OmitEmpty: false,
+	}
+	testLookup(t, in, "name", expected)
+}
+
+func TestLookupIgnore(t *testing.T) {
+	in := `name:"-" json:"b"`
+	expected := &Value{
+		Ignore:    true,
+		Name:      "",
+		OmitEmpty: false,
+	}
+	testLookup(t, in, "name", expected)
+}
+
+func TestLookupOmitEmpty(t *testing.T) {
+	in := `name:"a,omitempty" json:"b"`
+	expected := &Value{
+		Ignore:    false,
+		Name:      "a",
+		OmitEmpty: true,
+	}
+	testLookup(t, in, "name", expected)
+}

--- a/pkg/tagger/Lookup_test.go
+++ b/pkg/tagger/Lookup_test.go
@@ -14,12 +14,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type testStruct struct {
-	A string `name:"a"`
-	B string `name:"b,omitempty"`
-	C string `name:"-"`
-}
-
 func testLookup(t *testing.T, in string, key string, expected *Value) {
 	v, err := Lookup(reflect.StructTag(in), key)
 	assert.NoError(t, err)

--- a/pkg/tagger/Unmarshal.go
+++ b/pkg/tagger/Unmarshal.go
@@ -1,0 +1,14 @@
+// =================================================================
+//
+// Copyright (C) 2019 Spatial Current, Inc. - All Rights Reserved
+// Released as open source under the MIT License.  See LICENSE file.
+//
+// =================================================================
+
+// Package tagger includes a struct for marshaling and unmarshaling struct tags.
+package tagger
+
+// Unmarshal unmarshal the struct tag value into the Value object.
+func Unmarshal(text []byte, value *Value) error {
+	return value.UnmarshalText(text)
+}

--- a/pkg/tagger/Value.go
+++ b/pkg/tagger/Value.go
@@ -1,0 +1,76 @@
+// =================================================================
+//
+// Copyright (C) 2019 Spatial Current, Inc. - All Rights Reserved
+// Released as open source under the MIT License.  See LICENSE file.
+//
+// =================================================================
+
+// Package tagger includes a struct for marshaling and unmarshaling struct tags.
+package tagger
+
+import (
+	"strings"
+)
+
+type Value struct {
+	Ignore    bool
+	Name      string
+	OmitEmpty bool
+}
+
+// UnmarshalText unmarshals the given struct tag value into a Value object.
+func (t *Value) UnmarshalText(text []byte) error {
+	str := string(text)
+
+	if len(str) == 0 {
+		t.Ignore = false
+		t.Name = ""
+		t.OmitEmpty = false
+		return nil
+	}
+
+	if str == "-" {
+		t.Ignore = true
+		t.Name = ""
+		t.OmitEmpty = false
+		return nil
+	}
+
+	if str == ",omitempty" {
+		t.Ignore = false
+		t.Name = ""
+		t.OmitEmpty = true
+		return nil
+	}
+
+	if strings.Contains(str, ",") {
+		t.Ignore = false
+		parts := strings.Split(str, ",")
+		t.Name = parts[0]
+		attrs := map[string]struct{}{}
+		for _, p := range parts[1:] {
+			attrs[p] = struct{}{}
+		}
+		_, omitEmpty := attrs["omitempty"]
+		t.OmitEmpty = omitEmpty
+		return nil
+	}
+
+	t.Ignore = false
+	t.Name = str
+	t.OmitEmpty = false
+	return nil
+}
+
+// MarshalText returns the Value formatted as a struct tag value.
+// Always returns a nil error.
+func (t Value) MarshalText() ([]byte, error) {
+	if t.Ignore {
+		return []byte("-"), nil
+	}
+	str := t.Name
+	if t.OmitEmpty {
+		str += ",omitempty"
+	}
+	return []byte(str), nil
+}

--- a/pkg/tagger/Value_test.go
+++ b/pkg/tagger/Value_test.go
@@ -1,0 +1,64 @@
+// =================================================================
+//
+// Copyright (C) 2019 Spatial Current, Inc. - All Rights Reserved
+// Released as open source under the MIT License.  See LICENSE file.
+//
+// =================================================================
+
+package tagger
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func testValue(t *testing.T, in string, expected *Value) {
+	v := &Value{}
+	err := v.UnmarshalText([]byte(in))
+	assert.NoError(t, err)
+	assert.Equal(t, expected, v)
+	out, err := v.MarshalText()
+	assert.NoError(t, err)
+	assert.Equal(t, in, string(out))
+}
+
+func TestEmptyString(t *testing.T) {
+	testValue(t, "", &Value{
+		Ignore:    false,
+		Name:      "",
+		OmitEmpty: false,
+	})
+}
+
+func TestOmitEmpty(t *testing.T) {
+	testValue(t, ",omitempty", &Value{
+		Ignore:    false,
+		Name:      "",
+		OmitEmpty: true,
+	})
+}
+
+func TestIgnore(t *testing.T) {
+	testValue(t, "-", &Value{
+		Ignore:    true,
+		Name:      "",
+		OmitEmpty: false,
+	})
+}
+
+func TestName(t *testing.T) {
+	testValue(t, "foo", &Value{
+		Ignore:    false,
+		Name:      "foo",
+		OmitEmpty: false,
+	})
+}
+
+func TestNameOmitEmpty(t *testing.T) {
+	testValue(t, "foo,omitempty", &Value{
+		Ignore:    false,
+		Name:      "foo",
+		OmitEmpty: true,
+	})
+}


### PR DESCRIPTION
This PR adds two packages `pkg/mapper` and `pkg/tagger`.  Tagger provides a facility to parse struct tag values.  Mapper provides a facility to marshal a struct into a map and unmarshal a map into a struct.